### PR TITLE
missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
     "url": "git://github.com/uiureo/node-screencapture.git"
   },
   "license": "MIT",
+  "dependencies": {
+    "tmp": "0.0.23"
+  },
   "devDependencies": {
     "standard": "^5.3.1",
     "tap-spec": "^4.1.0",
-    "tape": "^2.14.0",
-    "tmp": "0.0.23"
+    "tape": "^2.14.0"
   }
 }


### PR DESCRIPTION
webpack build fails with the following error:

``` log
ERROR in ./~/screencapture/index.js
Module not found: Error: Cannot resolve module 'tmp' in /path/to/project/node_modules/screencapture
 @ ./~/screencapture/index.js 1:10-24
```

You probably need to move `tmp` module from `devDependencies`  to `dependencies`.
